### PR TITLE
Expose registration visibility toggle for user profile attributes

### DIFF
--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttribute.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttribute.java
@@ -45,6 +45,7 @@ public class UPAttribute implements Cloneable {
     private String group;
     private boolean multivalued;
     private String defaultValue;
+    private boolean userRegistrationHidden;
 
     public UPAttribute() {
     }
@@ -165,9 +166,17 @@ public class UPAttribute implements Cloneable {
         return multivalued;
     }
 
+    public boolean isUserRegistrationHidden() {
+        return userRegistrationHidden;
+    }
+
+    public void setUserRegistrationHidden(boolean userRegistrationHidden) {
+        this.userRegistrationHidden = userRegistrationHidden;
+    }
+
     @Override
     public String toString() {
-        return "UPAttribute [name=" + name + ", displayName=" + displayName + ", permissions=" + permissions + ", selector=" + selector + ", required=" + required + ", validations=" + validations + ", annotations=" + annotations + ", group=" + group + ", multivalued=" + multivalued + ", defaultValue=" + defaultValue + "]";
+        return "UPAttribute [name=" + name + ", displayName=" + displayName + ", permissions=" + permissions + ", selector=" + selector + ", required=" + required + ", validations=" + validations + ", annotations=" + annotations + ", group=" + group + ", multivalued=" + multivalued + ", defaultValue=" + defaultValue + ", userRegistrationHidden=" + userRegistrationHidden + "]";
     }
 
     @Override
@@ -194,6 +203,7 @@ public class UPAttribute implements Cloneable {
         attr.setGroup(this.group);
         attr.setMultivalued(this.multivalued);
         attr.setDefaultValue(this.defaultValue);
+        attr.setUserRegistrationHidden(this.userRegistrationHidden);
         return attr;
     }
 

--- a/js/apps/account-ui/src/api/representations.ts
+++ b/js/apps/account-ui/src/api/representations.ts
@@ -89,6 +89,7 @@ export interface UserProfileAttributeMetadata {
   validators: { [index: string]: { [index: string]: any } };
   multivalued: boolean;
   defaultValue: string;
+  userRegistrationHidden?: boolean;
 }
 
 export interface UserProfileMetadata {

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ca.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ca.properties
@@ -309,3 +309,6 @@ clearFileExplain=Esteu segur que voleu esborrar el fitxer?
 resetPasswordAllowed=He oblidat la contrasenya
 emptyExecution=Cap pas
 trusted-hosts.label=Amfitrions de confiança
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_de.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_de.properties
@@ -1693,3 +1693,6 @@ importKeysError=Fehler beim Importieren der Schlüssel. {{error}}
 forbidden_one=Verboten, Berechtigung erforderlich:
 supportedApplications=Unterstützte Anwendungen
 deletedErrorIdentityProvider=Der Anbieter konnte nicht gelöscht werden {{error}}
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_el.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_el.properties
@@ -1,0 +1,3 @@
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_es.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_es.properties
@@ -3511,3 +3511,6 @@ samlClientEncryptionDigestMethod=Método de resumen para RSA-OAEP
 samlClientEncryptionDigestMethodHelp=Método de resumen a utilizar cuando se selecciona cualquier algoritmo RSA-OAEP como algoritmo de transporte de clave. Valor predeterminado: SHA-256.
 samlClientEncryptionMaskGenerationFunction=Función de generación de máscara
 samlClientEncryptionMaskGenerationFunctionHelp=Función de generación de máscara a utilizar cuando se selecciona RSA-OAEP-11 como algoritmo de transporte de clave. Valor predeterminado: mgf1sha256.
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_fr.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_fr.properties
@@ -3597,3 +3597,6 @@ emailPendingVerificationUpdateError=Impossible de supprimer l'adresse de courrie
 userNotYetConfirmedNewEmail=L'utilisateur n'a pas confirmé la nouvelle adresse de courriel {{email}}.
 clientAuthentications.client_secret_basic_unencoded=Secret envoyé comme une authentification HTTP basique sans encodage des URL (obsolète)
 getKeyInfoError=Impossible de lire les informations du certificat {{error}}
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_it.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_it.properties
@@ -68,3 +68,6 @@ internationalizationHelp=Se abilitato, è possibile scegliere quali lingue suppo
 managePriorityOrder=Gestire l'ordine di priorità
 overrideActionTokens=Sovrascrivere gli Action Token
 deleteGrantsError=Errore nell'eliminazione dei grant: {{error}}
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ja.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ja.properties
@@ -3513,3 +3513,6 @@ samlClientEncryptionMaskGenerationFunction=マスク生成機能
 samlClientEncryptionMaskGenerationFunctionHelp=鍵転送アルゴリズムとしてRSA-OAEP-11を選択した場合に使用するマスク生成関数。デフォルト値はmgf1sha256です。
 allowutf8=UTF-8の許可
 showInAccountConsole=アカウントコンソールに表示する
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ka.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ka.properties
@@ -1374,3 +1374,6 @@ workflowDeleteConfirm=წავშალო სამუშაო პროც�
 groupObjectClasses=ობიექტის კლასების დაჯგუფება
 revokeRefreshToken=განახლების ტოკენის გაუქმება
 eventTypes.EXECUTE_ACTION_TOKEN.description=ქმედების ტოკენის შესრულება
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_kk.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_kk.properties
@@ -3515,3 +3515,5 @@ oid4vciEnabled=OID4VCI қосу
 oid4vciEnabledHelp=Клиентке Keycloak-тың OID4VCI тіркелгі деректері соңғы нүктесінен тексерілетін тіркелгі деректерін сұрауға рұқсат беру үшін осы опцияны қосыңыз.
 noAccessPolicies=Қол жеткізу саясаттары жоқ
 noAccessPoliciesInstructions=Әлі ешқандай қол жеткізу саясаттары конфигурацияланбаған. Бірінші саясатты конфигурациялау үшін төмендегі батырманы басыңыз.
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ky.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ky.properties
@@ -3496,3 +3496,5 @@ givenNameClaim=Берилген аты талабы
 givenNameClaimHelp=Колдонуучу профилин кайтарган JSON документиндеги берилген атын көрсөтүүчү талаптын аты. Эгер берилбесе, `given_name` колдонулат.
 familyNameClaim=Фамилия талабы
 familyNameClaimHelp=Колдонуучу профилин кайтарган JSON документиндеги фамилиясын көрсөтүүчү талаптын аты. Эгер берилбесе, `family_name` колдонулат.
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_lt.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_lt.properties
@@ -567,3 +567,6 @@ usermodel.prop.tooltip=Sąsajos UserModel atributo metodo pavadinimas. Pavyzdži
 user=Naudotojas
 times.days=Dienos
 providers=Teikėjai
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_nl.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_nl.properties
@@ -1,3 +1,6 @@
 fileUploadPreviewDisabled=Voorvertoning uitgeschakeld omdat de inhoud te lang is.
 addProvider_one=Voeg {{provider}} provider toe
 editUSernameHelp=Wanneer ingeschakeld, kunt u de gebruikersnaam bewerken. Anders is deze alleen-lezen.
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_no.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_no.properties
@@ -529,3 +529,6 @@ usermodel.prop.tooltip=Navn på egenskapsmetoden i UserModel-grensesnittet. For 
 user=Bruker
 times.days=Dager
 providers=Leverandører
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_pl.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_pl.properties
@@ -3327,3 +3327,6 @@ deleteConfirmUsers_other=Usunąć {{count}} użytkowników?
 downloadThemeJar=Pobierz plik JAR motywu
 themeColorInfo=Tutaj możesz ustawić zmienne kolorów PatternFly i utworzyć plik "theme jar", który możesz pobrać i umieścić w swoim folderze dostawcy, aby zastosować motyw w swoim obszarze.
 permissionsSubTitle=Precyzyjne uprawnienia administracyjne pozwalają na przypisanie szczegółowych, specyficznych praw dostępu, kontrolując, które zasoby i działania mogą być zarządzane.
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_pt_BR.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_pt_BR.properties
@@ -1153,3 +1153,6 @@ allow-default-scopes.label=Permitir escopos padrão
 minuteHelp=Define o minuto em que a política DEVE ser concedida. Você também pode fornecer um intervalo preenchendo o segundo campo. Nesse caso, a permissão será concedida apenas se o minuto atual estiver entre ou for igual aos dois valores fornecidos.
 updateCibaSuccess=Política CIBA atualizada com sucesso
 newRoleNameHelp=O novo nome do papel. O novo formato do nome corresponde à posição em que o papel será mapeado dentro do token de acesso. Assim, um novo nome como 'myapp.newname' mapeará o papel para essa posição no token de acesso. Um novo nome como 'newname' mapeará o papel para os papéis do realm no token.
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ro.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ro.properties
@@ -12,3 +12,6 @@ sync-ldap-roles-to-keycloak=Sincronizează rolurile LDAP cu Keycloak
 eventTypes.PERMISSION_TOKEN.name=Jeton de permisiune
 permissionsDisable=Dezactivați permisiunile?
 createClientPolicy=Creați o politică client
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ru.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_ru.properties
@@ -3578,3 +3578,6 @@ reGenerateEncryptionExplain=Если вы повторно сгенерируе�
 reGenerateEncryption=Повторно сгенерировать ключ шифрования для этого клиента
 samlclientSignatureCertificateHelp=Клиентский сертификат открытого ключа для проверки запросов и ответов SAML, подписанных клиентом SAML.
 samlencryptAssertionsCertificateHelp=Клиентский сертификат открытого ключа для шифрования утверждений SAML.
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_sl.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_sl.properties
@@ -1,3 +1,6 @@
 cancel=Prekliči
 deleteConfirm_other=Ali ste prepričani, da želite izbrisati te skupine?
 userID=ID uporabnika
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_tr.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_tr.properties
@@ -3597,3 +3597,6 @@ emailPendingVerificationUpdateError=Bekleyen e-posta doğrulaması kaldırılama
 userNotYetConfirmedNewEmail=Kullanıcı, {{email}} yeni e-posta adresini henüz doğrulamadı.
 clientAuthentications.client_secret_basic_unencoded=Client secret, URL encoding olmadan HTTP Basic kimlik doğrulaması olarak gönderildi (kullanımdan kaldırıldı)
 getKeyInfoError=Sertifika bilgileri okunamadı {{error}}
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_zh_Hans.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_zh_Hans.properties
@@ -2827,3 +2827,6 @@ titleAuthentication=身份验证
 category=目录
 startBySearchingAUser=从搜索用户开始
 times.days=天
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_zh_Hant.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_zh_Hant.properties
@@ -2981,3 +2981,6 @@ userGroupsRetrieveStrategy=使用者群組檢索策略
 addSubFlow=新增子流程
 client-uris-must-match.label=應用程式 URI 必須匹配
 consensus=共識
+
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3193,6 +3193,8 @@ bruteForceMode=Brute Force Mode
 error-invalid-multivalued-size=Attribute {{0}} must have at least {{1}} and at most {{2}} value(s).
 multivalued=Multivalued
 multivaluedHelp=If this attribute supports multiple values. This setting is an indicator and does not enable any validation.
+hideOnRegistrationPage=Hide on registration page
+hideOnRegistrationPageHelp=If enabled, the attribute will not appear on the user registration page. It will remain available in other contexts.
 defaultValue=Default value
 defaultValueHelp=Default value when attribute value is not specified.
 to the attribute. For that, make sure to use any of the built-in validators to properly validate the size and the values.

--- a/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
@@ -182,6 +182,10 @@ export default function NewAttributeSettings() {
       form.setValue("isRequired", required !== undefined);
       form.setValue("multivalued", multivalued === true);
       form.setValue("defaultValue", defaultValue);
+      form.setValue(
+        "userRegistrationHidden",
+        values.userRegistrationHidden === true,
+      );
     },
     [],
   );
@@ -228,6 +232,7 @@ export default function NewAttributeSettings() {
             selector: formFields.selector,
             permissions: formFields.permissions!,
             multivalued: formFields.multivalued,
+            userRegistrationHidden: formFields.userRegistrationHidden,
             annotations,
             validations,
           },
@@ -249,6 +254,7 @@ export default function NewAttributeSettings() {
             selector: formFields.selector,
             permissions: formFields.permissions!,
             multivalued: formFields.multivalued,
+            userRegistrationHidden: formFields.userRegistrationHidden,
             annotations,
             validations,
           },

--- a/js/apps/admin-ui/src/realm-settings/user-profile/attribute/AttributeGeneralSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/attribute/AttributeGeneralSettings.tsx
@@ -141,6 +141,11 @@ export const AttributeGeneralSettings = () => {
           label={t("multivalued")}
           labelIcon={t("multivaluedHelp")}
         />
+        <DefaultSwitchControl
+          name="userRegistrationHidden"
+          label={t("hideOnRegistrationPage")}
+          labelIcon={t("hideOnRegistrationPageHelp")}
+        />
         {!ROOT_ATTRIBUTE.includes(attributeName) && (
           <TextControl
             name="defaultValue"

--- a/js/libs/keycloak-admin-client/src/defs/userProfileMetadata.ts
+++ b/js/libs/keycloak-admin-client/src/defs/userProfileMetadata.ts
@@ -16,6 +16,7 @@ export interface UserProfileAttribute {
   group?: string;
   multivalued?: boolean;
   defaultValue?: string;
+  userRegistrationHidden?: boolean;
 }
 export interface UserProfileAttributeRequired {
   roles?: string[];
@@ -45,6 +46,7 @@ export interface UserProfileAttributeMetadata {
   validators?: Record<string, Record<string, unknown>>;
   multivalued?: boolean;
   defaultValue?: string;
+  userRegistrationHidden?: boolean;
 }
 
 export interface UserProfileAttributeGroupMetadata {

--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
@@ -267,6 +267,10 @@ public class DeclarativeUserProfileProvider implements UserProfileProvider {
                 continue;
             }
 
+            if (UserProfileContext.REGISTRATION.equals(context) && attrConfig.isUserRegistrationHidden()) {
+                continue;
+            }
+
             List<AttributeValidatorMetadata> validators = new ArrayList<>();
             Map<String, Map<String, Object>> validationsConfig = attrConfig.getValidations();
 


### PR DESCRIPTION
## Summary
- add the userRegistrationHidden property to admin client and account metadata types
- expose a Hide on registration page switch in the attribute form so admins can toggle the flag
- persist the new setting when saving attributes and add translation strings for all locales

## Testing
- pnpm -C js/apps/admin-ui lint

------
https://chatgpt.com/codex/tasks/task_e_69008012700483318451e88ff6942dc5